### PR TITLE
Minor patch to the precedence system

### DIFF
--- a/yacc.lisp
+++ b/yacc.lisp
@@ -844,13 +844,17 @@ PRECEDENCE is a list of elements of the form (KEYWORD . (op...))."
     ((member op (cdar precedence)) precedence)
     (t (find-precedence op (cdr precedence)))))
 
+(defun precd-terminal-p (symbol grammar)
+  (and (terminal-p symbol grammar)
+       (find-precedence symbol (grammar-precedence grammar))))
+
 (defun find-single-terminal (s grammar)
   "Return the only terminal in S, or NIL if none or multiple."
   (declare (list s) (type grammar grammar))
   (cond
     ((null s) nil)
-    ((terminal-p (car s) grammar)
-     (and (not (member-if #'(lambda (s) (terminal-p s grammar)) (cdr s)))
+    ((precd-terminal-p (car s) grammar)
+     (and (not (member-if #'(lambda (s) (precd-terminal-p s grammar)) (cdr s)))
           (car s)))
     (t (find-single-terminal (cdr s) grammar))))
 


### PR DESCRIPTION
There are cases where a production will have more than one terminal but only one of them will actually be in the precedence list. In this case cl-yacc is unable to resolve the precedence even when it would seem relatively obvious to the user. This minor patch (while admittedly a rather inefficient solution to the problem) instead only searches for terminals that are also in the precedence list in the most obvious way possible. If I had more time I would be happy to refactor the code somewhat to remove the extra calls to find-precedence, but I figured I should bring this to your attention before I went further.